### PR TITLE
Query2 builder that prevents execution until you have selected at least ...

### DIFF
--- a/src/main/scala/com/gravity/hbase/schema/HbaseTable.scala
+++ b/src/main/scala/com/gravity/hbase/schema/HbaseTable.scala
@@ -412,7 +412,7 @@ abstract class HbaseTable[T <: HbaseTable[T, R, RR], R, RR <: HRow[T, R]](val ta
   @deprecated("Use query2 instead")
   def query = new Query(this)
 
-  def query2 = new Query2(this)
+  def query2 = new Query2Builder(this)
 
   def put(key: R, writeToWAL: Boolean = true) = new PutOp(this, keyConverter.toBytes(key))
 

--- a/src/main/scala/com/gravity/hbase/schema/Query2Builder.scala
+++ b/src/main/scala/com/gravity/hbase/schema/Query2Builder.scala
@@ -1,0 +1,23 @@
+package com.gravity.hbase.schema
+
+class Query2Builder[T <: HbaseTable[T, R, RR], R, RR <: HRow[T, R]] private[schema](override val table: HbaseTable[T, R, RR]) extends BaseQuery[T, R, RR] with MinimumFiltersToExecute[T, R, RR] {
+
+  def withAllColumns = new Query2(table, keys, families, columns, currentFilter, startRowBytes, endRowBytes, batchSize, startTime, endTime)
+
+  override def withFamilies[F](firstFamily: (T) => ColumnFamily[T, R, F, _, _], familyList: ((T) => ColumnFamily[T, R, F, _, _])*) = {
+    withAllColumns.withFamilies(firstFamily, familyList: _*)
+  }
+
+  override def withColumn[F, K, V](family: (T) => ColumnFamily[T, R, F, K, V], columnName: K) = {
+    withAllColumns.withColumn(family, columnName)
+  }
+
+  override def withColumn[F, K, V](column: (T) => Column[T, R, F, K, V]) = {
+    withAllColumns.withColumn(column)
+  }
+
+  override def withColumns[F, K, V](firstColumn: (T) => Column[T, R, F, _, _], columnList: ((T) => Column[T, R, F, _, _])*) = {
+    withAllColumns.withColumns(firstColumn, columnList: _*)
+  }
+
+}

--- a/src/test/scala/com/gravity/hbase/schema/WebCrawlSchemaTest.scala
+++ b/src/test/scala/com/gravity/hbase/schema/WebCrawlSchemaTest.scala
@@ -204,7 +204,7 @@ class WebCrawlSchemaTest extends HPasteTestCase(WebCrawlingSchema) {
 
     val res = (op1 + op2).execute()
 
-    val results = WebCrawlingSchema.WebTable.query2.withKeys(Set(url1,url2)).executeMap()
+    val results = WebCrawlingSchema.WebTable.query2.withKeys(Set(url1,url2)).withAllColumns.executeMap()
 
     Assert.assertEquals("Addition1",results(url1).column(_.title).get)
     Assert.assertEquals("How stop blop blop?",results(url1).column(_.article).get)
@@ -238,7 +238,7 @@ class WebCrawlSchemaTest extends HPasteTestCase(WebCrawlingSchema) {
 
     new WebSearchAggregationJob().run(Settings.None, LocalCluster.getTestConfiguration)
 
-    WebCrawlingSchema.Sites.query2.withKey("mycrawledsite.com").singleOption() match {
+    WebCrawlingSchema.Sites.query2.withKey("mycrawledsite.com").withAllColumns.singleOption() match {
       case Some(siteRow) => {
         siteRow.family(_.searchMetrics).foreach {println}
       }
@@ -285,10 +285,10 @@ class WebCrawlSchemaTest extends HPasteTestCase(WebCrawlingSchema) {
       WebCrawlingSchema.WebTable.put(longUrl2).value(_.title, longUrl2).execute()
     }
 
-    val results = WebCrawlingSchema.WebTable.query2.filter(_.or(_.columnValueMustContain(_.title,site1))).scanToIterable(itm=>itm)
+    val results = WebCrawlingSchema.WebTable.query2.withAllColumns.filter(_.or(_.columnValueMustContain(_.title,site1))).scanToIterable(itm=>itm)
     Assert.assertTrue(results.size == 4)
 
-    val results2 = WebCrawlingSchema.WebTable.query2.filter(_.or(_.columnValueMustContain(_.title,site2))).scanToIterable(itm=>itm)
+    val results2 = WebCrawlingSchema.WebTable.query2.withAllColumns.filter(_.or(_.columnValueMustContain(_.title,site2))).scanToIterable(itm=>itm)
     Assert.assertTrue(results2.size == 4)
 
   }
@@ -301,7 +301,7 @@ class WebCrawlSchemaTest extends HPasteTestCase(WebCrawlingSchema) {
     WebCrawlingSchema.WebTable.put("http://hithere.com/yo").value(_.title,"Hi, this will be deleted").execute()
     WebCrawlingSchema.WebTable.delete("http://hithere.com/yo").execute()
 
-    WebCrawlingSchema.WebTable.query2.withKey("http://hithere.com/yo").singleOption() match {
+    WebCrawlingSchema.WebTable.query2.withKey("http://hithere.com/yo").withAllColumns.singleOption() match {
       case Some(result) => {
         Assert.fail("Deletion did not go through")
       }
@@ -315,12 +315,12 @@ class WebCrawlSchemaTest extends HPasteTestCase(WebCrawlingSchema) {
     WebCrawlingSchema.WebTable.put("http://batching.com/article2").value(_.title,"Batch Title 2").value(_.article,"Content 2").execute()
     WebCrawlingSchema.WebTable.put("http://batching.com/article3").value(_.title,"Batch Title 3").value(_.article,"Content 3").execute()
     WebCrawlingSchema.WebTable.put("http://batching.com/article4").value(_.title,"Batch Title 4").value(_.article,"Content 4").execute()
-    WebCrawlingSchema.WebTable.query2.withBatchSize(1).scan({page=>
+    WebCrawlingSchema.WebTable.query2.withAllColumns.withBatchSize(1).scan({page=>
        page.prettyPrintNoValues()
       Assert.assertTrue(page.size <= 1)
     })
 
-    WebCrawlingSchema.WebTable.query2.withBatchSize(2).scan({page=>
+    WebCrawlingSchema.WebTable.query2.withAllColumns.withBatchSize(2).scan({page=>
        page.prettyPrintNoValues()
       Assert.assertTrue(page.size <= 2)
     })


### PR DESCRIPTION
...one column or family. withColumns(column_) and withFamilies(familiy_) now require at least one arg.

Fixes accidental massive column selections on wide rows. You can still get all columns with .withAllColumns.

Moved all BaseQuery fields to be in one place.
